### PR TITLE
Rename renovate.json to renovate.json5 and use config:recommended

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "extends": ["config:recommended"],
   "enabledManagers": ["dockerfile", "regex"],
   "packageRules": [
     {


### PR DESCRIPTION
- The config uses JSON5-only syntax; Renovate warns JSON5-in-`.json` support will be removed. Renaming to `renovate.json5` is the recommended remedy and preserves parsing behavior.
- Replaces deprecated `config:base` with `config:recommended`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)